### PR TITLE
Fix email user

### DIFF
--- a/cap_gun.gemspec
+++ b/cap_gun.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{cap_gun}
-  s.version = "0.2.6.doxo"
+  s.version = "0.2.7.doxo"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Rob Sanheim", "Muness Alrubaie", "Relevance"]

--- a/lib/cap_gun/presenter.rb
+++ b/lib/cap_gun/presenter.rb
@@ -24,7 +24,7 @@ module CapGun
     end
 
     def current_user
-      ENV["LC_BUILD_USER_ID"].nil? ? Etc.getlogin : ENV["LC_BUILD_USER_ID"]
+      ENV.fetch("BUILD_USER_ID", Etc.getlogin)
     end
 
     def summary

--- a/lib/cap_gun/presenter.rb
+++ b/lib/cap_gun/presenter.rb
@@ -24,7 +24,7 @@ module CapGun
     end
 
     def current_user
-      Etc.getlogin
+      ENV["LC_BUILD_USER_ID"].nil? ? Etc.getlogin : ENV["LC_BUILD_USER_ID"]
     end
 
     def summary


### PR DESCRIPTION
This is a dumb fix but it works. If we create an environment variable in Jenkins named "LC_BUILD_USER_ID" and set it to BUILD_USER_ID, the name of the user running the build, we can inject it into the build process and ssh will allow it to pass through because it looks like a locale environment variable.